### PR TITLE
Change the version of the solidity to 0.8.7

### DIFF
--- a/SimpleStorage.sol
+++ b/SimpleStorage.sol
@@ -1,7 +1,7 @@
 // I'm a comment!
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.8;
+pragma solidity 0.8.7;
 // pragma solidity ^0.8.0;
 // pragma solidity >=0.8.0 <0.9.0;
 


### PR DESCRIPTION
The reason for this change is that when moving over to the local environment, the version of solidity used with the library solc is fixed for 0.8.7. So if someone were to copy and paste the code, it wouldn't work. By changing it to 0.8.7, it will work with the fixed compiler.